### PR TITLE
Update crud_user.py KeyError

### DIFF
--- a/{{cookiecutter.project_slug}}/backend/app/app/crud/crud_user.py
+++ b/{{cookiecutter.project_slug}}/backend/app/app/crud/crud_user.py
@@ -31,7 +31,7 @@ class CRUDUser(CRUDBase[User, UserCreate, UserUpdate]):
             update_data = obj_in
         else:
             update_data = obj_in.dict(exclude_unset=True)
-        if update_data["password"]:
+        if update_data.get("password"):
             hashed_password = get_password_hash(update_data["password"])
             del update_data["password"]
             update_data["hashed_password"] = hashed_password

--- a/{{cookiecutter.project_slug}}/backend/app/app/tests/crud/test_user.py
+++ b/{{cookiecutter.project_slug}}/backend/app/app/tests/crud/test_user.py
@@ -92,3 +92,17 @@ def test_update_user(db: Session) -> None:
     assert user_2
     assert user.email == user_2.email
     assert verify_password(new_password, user_2.hashed_password)
+
+
+def test_update_user_not_password(db: Session) -> None:
+    password = random_lower_string()
+    email = random_email()
+    user_in = UserCreate(email=email, password=password, is_superuser=True)
+    user = crud.user.create(db, obj_in=user_in)
+    full_name = random_lower_string()
+    user_in_update = UserUpdate(full_name=full_name, is_superuser=True)
+    crud.user.update(db, db_obj=user, obj_in=user_in_update)
+    user_2 = crud.user.get(db, id=user.id)
+    assert user_2
+    assert user.email == user_2.email
+    assert user.full_name == user_2.full_name


### PR DESCRIPTION
When updating a user details but not their password the password key will not be in the `update_data` dict; therefore a `KeyError` is thrown when trying to directly call the key `password`. Using `.get("password")` will instead return nothing and be evaluated as false as expected.